### PR TITLE
WIP: fix cyclic update problems

### DIFF
--- a/webhook_story.go
+++ b/webhook_story.go
@@ -66,7 +66,7 @@ func parseWebhookStory(data []byte, githubHTMLURL string, trackerHTMLURL string)
 		}
 	}
 
-	if newTitle != nil || newBody != nil || newState != nil {
+	if newTitle != nil || newBody != nil {
 		story.githubHTMLURL = githubHTMLURL
 		story.URL = fmt.Sprintf("%s/story/show/%s", trackerHTMLURL, story.StoryID)
 		return &story, nil

--- a/webhook_story_handler_test.go
+++ b/webhook_story_handler_test.go
@@ -222,20 +222,7 @@ func TestGithubAPIClient(t *testing.T) {
 				Title:  "should create/update github issue on pt story create/update",
 				Body:   "Hello world",
 			},
-			expectedHistory: []logAction{
-				{
-					Method:             "FindIssue",
-					GivenTitle:         "should create/update github issue on pt story create/update",
-					GivenSearchFilters: []string{"should create/update github issue on pt story create/update in:title is:issue repo:user123/repo456"},
-					GivenState:         "closed",
-				},
-				{
-					Method:     "UpdateIssue",
-					GivenID:    "42",
-					GivenTitle: "should create/update github issue on pt story create/update",
-					GivenState: "closed",
-				},
-			},
+			expectedHistory: []logAction(nil),
 		},
 		{
 			givenFile: "testdata/tracker/story_update_activity.delete.json",
@@ -244,23 +231,7 @@ func TestGithubAPIClient(t *testing.T) {
 				Title:  "should create/update github issue on pt story create/update",
 				Body:   "https://www.pivotaltracker.com/story/show/153926473\r\n\r\nHello world",
 			},
-			expectedHistory: []logAction{
-				{
-					Method:             "FindIssue",
-					GivenTitle:         "should create/update github issue on pt story create/update" + noStorySuffix,
-					GivenSearchFilters: []string{"should create/update github issue on pt story create/update in:title is:issue repo:user123/repo456"},
-				},
-				{
-					Method:  "GetIssue",
-					GivenID: "42",
-				},
-				{
-					Method:     "UpdateIssue",
-					GivenID:    "42",
-					GivenTitle: "should create/update github issue on pt story create/update" + noStorySuffix,
-					GivenBody:  "Hello world",
-				},
-			},
+			expectedHistory: []logAction(nil),
 		},
 	}
 

--- a/webhook_story_test.go
+++ b/webhook_story_test.go
@@ -164,25 +164,14 @@ func TestWebhookStory(t *testing.T) {
 			expectedTitle:   "how it works now??",
 			expectedBody:    nil,
 			expectedStoryID: "153983933",
-			expectedGhIssue: issueDetail{
-				repo:          "user123/repo456",
-				id:            "",
-				Title:         "how it works now??",
-				State:         "open",
-				searchFilters: []string{"how it works now?? in:title is:issue repo:user123/repo456"},
-			},
+			expectNoStory:   true,
 		},
 		{
 			givenFile:       "testdata/tracker/story.deleted.json",
 			expectedTitle:   "how it works now??",
 			expectedBody:    nil,
 			expectedStoryID: "153983933",
-			expectedGhIssue: issueDetail{
-				repo:          "user123/repo456",
-				id:            "",
-				Title:         "how it works now??" + noStorySuffix,
-				searchFilters: []string{"how it works now?? in:title is:issue repo:user123/repo456"},
-			},
+			expectNoStory:   true,
 		},
 	}
 


### PR DESCRIPTION
- [x] creating stories and configuring them on PT sends extraneous webhooks to GH
    - we ignore the PT state changes finish, started, etc...; open/close GH issues manually
- [ ] also, we should fix #4 webhooks cross firing